### PR TITLE
add pipeline to build a new image and deploy a VMSS to Azure

### DIFF
--- a/images.CI/linux-and-win/azure-pipelines/agentpool-vmss.yml
+++ b/images.CI/linux-and-win/azure-pipelines/agentpool-vmss.yml
@@ -1,0 +1,51 @@
+# This template generates an Azure Pipeline Runner image and deploys it to an Azure Virtual Machine Scale Set
+
+parameters:
+  - name: azure_subscription
+    type: string
+
+  - name: agent_pool
+    type: object
+    default:
+      name: ubuntu-latest
+
+  - name: image_type
+    type: string
+
+  - name: image_template_name
+    type: string
+
+  - name: image_readme_name
+    type: string
+
+  - name: keyvault_name
+    type: string
+
+  - name: keyvault_secret_name
+    type: string
+
+  - name: variable_group_name
+    type: string
+    default: 'Image Generation Variables'
+
+  - name: repository_ref
+    type: string
+    default: 'self'
+
+stages:
+- stage: generate_image
+  displayName: generate ${{ parameters.image_type }} image
+  pool: ${{ parameters.agent_pool }}
+  jobs:
+  - template: image-generation.yml
+    parameters:
+      azureSubscription: ${{ parameters.azure_subscription }}
+      image_type: ${{ parameters.image_type }}
+      image_template_name: ${{ parameters.image_template_name }}
+      image_readme_name: ${{ parameters.image_readme_name }}
+      agent_pool: ${{ parameters.agent_pool }}
+      variable_group_name: ${{ parameters.variable_group_name }}
+      create_release: false
+      repository_ref: ${{ parameters.repository_ref }}
+      keyvault_name: ${{ parameters.keyvault_name }}
+      keyvault_secret_name: ${{ parameters.keyvault_secret_name }}


### PR DESCRIPTION
# Description
Add new pipeline template to allow forks to reference it and re-use this for manual or scheduled image generation and deployment to a VMSS in Azure. The goal is to allow deployment and patching for private agent pools using VMSS.

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ X ] Changes are tested and related VM images are successfully generated
